### PR TITLE
Fix unscoped when using postgres and raw queries 

### DIFF
--- a/src/scopes.js
+++ b/src/scopes.js
@@ -91,7 +91,7 @@ module.exports = function(bookshelf) {
       return this.query(function function_name(qb) {
         // Remove scoped statements
         _.remove(qb._statements, function (statement) {
-          return unscoped.scopeStatements.some(scopeStatement => _.isEqual(scopeStatement, statement));
+          return unscoped.scopeStatements.some(scopeStatement => _.isMatch(scopeStatement, statement));
         });
         // Clear scoped statements registry
         unscoped.scopeStatements = [];

--- a/src/scopes.js
+++ b/src/scopes.js
@@ -91,7 +91,7 @@ module.exports = function(bookshelf) {
       return this.query(function function_name(qb) {
         // Remove scoped statements
         _.remove(qb._statements, function (statement) {
-          return unscoped.scopeStatements.some(_.matches(statement));
+          return unscoped.scopeStatements.some(scopeStatement => _.isEqual(scopeStatement, statement));
         });
         // Clear scoped statements registry
         unscoped.scopeStatements = [];

--- a/test/scopes_default.js
+++ b/test/scopes_default.js
@@ -90,6 +90,7 @@ describe('scopes - default', function() {
       scopes: {
         default: function(qb) {
           qb.where({status: 'Active'});
+          qb.whereRaw('created_at > now()');
         }
       }
     });


### PR DESCRIPTION
Should fix https://github.com/jtwebman/bookshelf-scopes/issues/4.

This change should be non-controversial: `_.isMatch(object, source)` is equivalent to `_.matches(source)(object)`, but `_.isMatch` doesn't deep clone the source.

I've updated a test to "cover" this (in the hopes that perhaps eventually it'll be valuable), but unfortunately we'd need unit tests against postgres, too, instead of just sqlite, to confirm that this issue isn't occurring. Note that the test wouldn't _fail_ if the issue exists, it would simply log an error and succeed anyways. (In the project I'm working on, this issue only seems to cause tests to fail when many concurrent connections are already open, and with many tests being run. I don't know what the exact problem is, but I'm not sure it's worth it to spend a bunch of time trying to design a more effective test; this should at least log an error when it's occurring)

That said, I've manually tested against another project which does use postgres, and it seems the issue has disappeared with this change (and generally that unscoping works as before).